### PR TITLE
remove payload overriding with redis set status

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -10,7 +10,7 @@
     ],
     "releases": [
         {
-            "tagName": "v3.1.2",
+            "tagName": "v3.1.3",
             "products": [
                 "MI 1.2.0",
                 "MI 4.x.x"

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.redis</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.3-SNAPSHOT</version>
+    <version>3.1.4-SNAPSHOT</version>
     <name>WSO2 Carbon - Mediation Library Connector For Redis</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/resources/hashes/hSet.xml
+++ b/src/main/resources/hashes/hSet.xml
@@ -27,15 +27,5 @@
         <property name="redisValue" expression="$func:redisValue"/>
         <class name="org.wso2.carbon.connector.operations.HSet"/>
         <property name="redisResponse" expression="$ctx:result"/>
-        <payloadFactory media-type="json">
-            <format>
-                {
-                    "output":$1
-                }
-            </format>
-            <args>
-                <arg evaluator="xml" expression="$ctx:redisResponse"/>
-            </args>
-        </payloadFactory>
     </sequence>
 </template>


### PR DESCRIPTION
The current implementation is overriding with payload with redis status for set operation. the set operation status is optional and user can access using redisResponse property
